### PR TITLE
make http-science a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # http-science
 
-http-science is an http service that forwards requests it receives to two locations, compares the responses, and reports any differences.
+http-science is an HTTP service that sends requests it receives to two locations, compares the responses, and reports any differences.
 
 ## Motivation
 
@@ -10,7 +10,7 @@ However, in practice there is often a lot of risk associated with these changes,
 
 "[Science](http://zachholman.com/talk/move-fast-break-nothing/)" is a pattern GitHub introduced for deploying changes to code paths that should not change the output of that code path.
 `http-science` is a tool for doing the same experimentation at the network level.
-Assuming you have two versions of an HTTP service deployed, it takes care of forwarding requests to both and reporting any difference in the HTTP responses.
+Assuming you have two versions of an HTTP service deployed, it takes care of sending requests to both and reporting any difference in the HTTP responses.
 
 ## Installation
 
@@ -18,14 +18,18 @@ Assuming you have two versions of an HTTP service deployed, it takes care of for
 
 ## Usage
 
-`http-science` the binary takes no arguments, but expects two environment variables:
+`http-science` the binary takes no arguments. It is configured via environment variables:
 
-* `CONTROL`: address (`DNS or IP`:`port`) of an http server. Responses will be considered as the "control" in the experiment, i.e. any deviation from the response returned from this server will be treated as significant.
-* `EXPERIMENT`: address of an http server. Responses from this server will be compared to responses to the `CONTROL` server.
+* `CONTROL_URL`: Required. URL to proxy requests to. Responses will be considered as the "control" in the experiment, i.e. any deviation from the response returned from this server will be treated as significant.
+* `EXPERIMENT_URL`: Required. Responses from this server will be compared to responses from the `CONTROL` server.
+* `EXPERIMENT_HTTP_METHODS`: comma-separated HTTP methods to experiment on, e.g. "GET,OPTIONS". Optional. Default is all methods.
+* `EXPERIMENT_HTTP_URL_REGEXP`: regex of URLs to experiment on, e.g. `^/api/.*`. Optional. Default is all URLs.
+* `EXPERIMENT_PERCENT`: percent of requests that match the above filters to sample from `CONTROL` and send to the experiment, e.g. to send all requests, set this to "100.0". Optional. Default is 0.
 
-Once launched, `http-science` listens for HTTP requests on port 80, and will forward any request it receives to both `CONTROL` and `EXPERIMENT`.
-If there is a difference in responses, it will log a report of the difference.
-
+Once launched, `http-science` listens for HTTP requests on port 80, and will proxy all requests it receives to `CONTROL`.
+A certain percentage of requests will get sent to `EXPERIMENT` in addition to getting sent to `CONTROL`.
+If there's a difference in response between `CONTROL` and `EXPERIMENT`, it will be logged.
+`http-science` always responds to requests with the response from `CONTROL`.
 
 ## Developing
 

--- a/main.go
+++ b/main.go
@@ -1,48 +1,63 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
-	"net"
+	"math/rand"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
+	"net/url"
 	"os"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 // Science is an http.Handler that forwards requests it receives to two places, logging any
 // difference in response.
 type Science struct {
-	ControlDial    string
-	ExperimentDial string
-	DiffLog        *log.Logger
+	ControlProxy                *httputil.ReverseProxy
+	ExperimentProxy             *httputil.ReverseProxy
+	ExperimentHTTPMethods       []string
+	ExperimentHTTPURLPathRegexp *regexp.Regexp
+	ExperimentPercent           float64
+	DiffLog                     *log.Logger
 }
 
-// forwardRequest forwards a request to an http server and returns the raw HTTP response.
-// It also removes the Date header from the returned response data so you can diff it against other
-// responses.
-func forwardRequest(r *http.Request, addr string) (string, error) {
-	conn, err := net.Dial("tcp", addr)
-	if err != nil {
-		return "", fmt.Errorf("error establishing tcp connection to %s: %s", addr, err)
+func in(str string, arr []string) bool {
+	for _, val := range arr {
+		if val == str {
+			return true
+		}
 	}
-	defer conn.Close()
-	read := bufio.NewReader(conn)
-	r.WriteProxy(conn)
-	res, err := http.ReadResponse(read, r)
-	if err != nil {
-		return "", fmt.Errorf("error reading response from %s: %s", addr, err)
+	return false
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
 	}
-	defer res.Body.Close()
-	delete(res.Header, "Date")
-	resDump, err := httputil.DumpResponse(res, true)
-	if err != nil {
-		return "", fmt.Errorf("error dumping response from %s: %s", addr, err)
-	}
-	return string(resDump), nil
 }
 
 func (s Science) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	// determine if we're going to sample this request
+	sample :=
+		(s.ExperimentHTTPMethods == nil || in(r.Method, s.ExperimentHTTPMethods)) &&
+			(s.ExperimentHTTPURLPathRegexp == nil || s.ExperimentHTTPURLPathRegexp.MatchString(r.URL.Path)) &&
+			(rand.Float64() < s.ExperimentPercent)
+
+	// if not sampling, proxy straight through
+	if !sample {
+		s.ControlProxy.ServeHTTP(w, r)
+		return
+	}
 
 	// save request for potential diff logging
 	reqDump, err := httputil.DumpRequest(r, true)
@@ -51,31 +66,53 @@ func (s Science) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	req := string(reqDump)
 
-	// forward requests to control and experiment, diff response
-	var resControl string
-	var resExperiment string
-	if resControl, err = forwardRequest(r, s.ControlDial); err != nil {
-		log.Printf("error forwarding request to control: %s", err)
-		return
-	}
-	if resExperiment, err = forwardRequest(r, s.ExperimentDial); err != nil {
-		log.Printf("error forwarding request to experiment: %s", err)
+	// proxy the request, but record the response for diffing
+	crecorder := httptest.NewRecorder()
+	s.ControlProxy.ServeHTTP(crecorder, r)
+	copyHeader(w.Header(), crecorder.HeaderMap)
+	w.WriteHeader(crecorder.Code)
+	controlBodyBytes := crecorder.Body.Bytes() // need to read twice, so pull it into memory
+	if _, err := io.Copy(w, bytes.NewReader(controlBodyBytes)); err != nil {
+		fmt.Printf("error copying data to response: %s", err)
 		return
 	}
 
-	if resControl != resExperiment {
+	// make same request to control
+	erecorder := httptest.NewRecorder()
+	s.ExperimentProxy.ServeHTTP(erecorder, r)
+
+	// diff response by getting the raw HTTP response
+	delete(crecorder.HeaderMap, "Date")
+	delete(erecorder.HeaderMap, "Date")
+	cresponse, err := httputil.DumpResponse(&http.Response{
+		StatusCode: crecorder.Code,
+		Header:     crecorder.HeaderMap,
+		Body:       ioutil.NopCloser(bytes.NewReader(controlBodyBytes)),
+	}, true)
+	if err != nil {
+		fmt.Printf("error dumping control response: %s", err)
+		return
+	}
+	eresponse, err := httputil.DumpResponse(&http.Response{
+		StatusCode: erecorder.Code,
+		Header:     erecorder.HeaderMap,
+		Body:       ioutil.NopCloser(erecorder.Body),
+	}, true)
+	if err != nil {
+		fmt.Printf("error dumping experiment response: %s", err)
+		return
+	}
+
+	if string(cresponse) != string(eresponse) {
 		s.DiffLog.Printf(`=== diff ===
 %s
----
+--- control ---
 %s
----
+--- experiment ---
 %s
 ============
-`, req, resControl, resExperiment)
+`, req, cresponse, eresponse)
 	}
-
-	// return 200 no matter what
-	fmt.Fprintf(w, "OK")
 }
 
 func main() {
@@ -84,9 +121,43 @@ func main() {
 			log.Fatalf("%s required", env)
 		}
 	}
+
+	// parse urls
+	controlurl, err := url.Parse(os.Getenv("CONTROL"))
+	if err != nil {
+		log.Fatalf("error parsing CONTROL: %s", err)
+	}
+	experimenturl, err := url.Parse(os.Getenv("EXPERIMENT"))
+	if err != nil {
+		log.Fatalf("error parsing EXPERIMENT: %s", err)
+	}
+
+	// optional env
+	var httpmethods []string
+	if methods := os.Getenv("EXPERIMENT_HTTP_METHODS"); methods != "" {
+		httpmethods = strings.Split(methods, ",")
+	}
+
+	var re *regexp.Regexp
+	if restring := os.Getenv("EXPERIMENT_HTTP_URL_PATH_REGEXP"); restring != "" {
+		if re, err = regexp.Compile(restring); err != nil {
+			log.Fatalf("error parsing EXPERIMENT_HTTP_URL_REGEXP: %s", err)
+		}
+	}
+
+	percent := 0.0
+	if percentstring := os.Getenv("EXPERIMENT_PERCENT"); percentstring != "" {
+		if percent, err = strconv.ParseFloat(percentstring, 64); err != nil {
+			log.Fatalf("error parsing EXPERIMENT_PERCENT: %s", err)
+		}
+	}
+
 	log.Fatal(http.ListenAndServe(":80", Science{
-		ControlDial:    os.Getenv("CONTROL"),
-		ExperimentDial: os.Getenv("EXPERIMENT"),
-		DiffLog:        log.New(os.Stdout, "", 0),
+		ControlProxy:                httputil.NewSingleHostReverseProxy(controlurl),
+		ExperimentProxy:             httputil.NewSingleHostReverseProxy(experimenturl),
+		ExperimentHTTPMethods:       httpmethods,
+		ExperimentHTTPURLPathRegexp: re,
+		ExperimentPercent:           percent,
+		DiffLog:                     log.New(os.Stdout, "", 0),
 	}))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,9 +3,13 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"text/template"
@@ -19,8 +23,8 @@ type Request struct {
 
 type Response struct {
 	//Code int
-	Body    string
-	Headers map[string]string
+	Body   string
+	Header http.Header
 }
 
 type TestCase struct {
@@ -31,26 +35,48 @@ type TestCase struct {
 }
 
 func (tc TestCase) Run(t *testing.T) {
+
+	// set up control andd experiment servers and their responses
 	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, tc.Control.Body)
 	}))
 	defer control.Close()
+	controlURL, _ := url.Parse(control.URL)
 	experiment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, tc.Experiment.Body)
 	}))
 	defer experiment.Close()
+	experimentURL, _ := url.Parse(experiment.URL)
+
+	// set up science server proxying both control and experiment
 	var output bytes.Buffer
 	scienceServer := httptest.NewServer(Science{
-		ControlDial:    strings.Replace(control.URL, "http://", "", -1),
-		ExperimentDial: strings.Replace(experiment.URL, "http://", "", -1),
-		DiffLog:        log.New(&output, "", 0),
+		ControlProxy:      httputil.NewSingleHostReverseProxy(controlURL),
+		ExperimentProxy:   httputil.NewSingleHostReverseProxy(experimentURL),
+		ExperimentPercent: 100.0,
+		DiffLog:           log.New(&output, "", 0),
 	})
 	defer scienceServer.Close()
-	_, err := http.Get(scienceServer.URL + tc.Request.Path)
+
+	// send the test request to the science server
+	resp, err := http.Get(scienceServer.URL + tc.Request.Path)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// verify we got a response from the control
+	if body, err := ioutil.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	} else if strings.TrimSpace(string(body)) != tc.Control.Body {
+		t.Fatalf("response body not proxied from control: got '%s', expected '%s'", string(body), tc.Control.Body)
+	}
+	for k, v := range tc.Control.Header {
+		if !reflect.DeepEqual(v, resp.Header[k]) {
+			t.Fatalf("response headers not proxied from control: got '%s: %s', expected '%s: %s'", k, v, k, resp.Header[k])
+		}
+	}
+
+	// verify that the output of the science logic is what we expect
 	templ := template.Must(template.New("output").Parse(tc.Output))
 	var expectedbuf bytes.Buffer
 	if err := templ.Execute(&expectedbuf, map[string]string{
@@ -59,7 +85,6 @@ func (tc TestCase) Run(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := expectedbuf.String()
-
 	outputstr := strings.Replace(output.String(), "\r\n", "\n", -1)
 	if outputstr != expected {
 		t.Fatalf("expected:\n'%s'\ngot:\n'%s'\n", expected, outputstr)
@@ -95,16 +120,14 @@ Accept-Encoding: gzip
 User-Agent: Go 1.1 package http
 
 
----
-HTTP/1.1 200 OK
-Content-Length: 9
+--- control ---
+HTTP/0.0 200 OK
 Content-Type: text/plain; charset=utf-8
 
 Server A
 
----
-HTTP/1.1 200 OK
-Content-Length: 9
+--- experiment ---
+HTTP/0.0 200 OK
 Content-Type: text/plain; charset=utf-8
 
 Server B


### PR DESCRIPTION
Before this change http-science was effectively a black hole--you sent it requests, and it would always return 200 with an empty response. This makes it somewhat difficult to deal with architecturally.

This change makes http-science proxy requests to CONTROL, i.e. it will respond to requests it receives with the response it receives from CONTROL. This makes it easier to deal with architecturally, since it can be used as a pass-through proxy.

Some things that I would specially like feedback on:
- Recording the response received when sending a request to a `http.Handler`: right now I try to recover an `http.Response` object from an `httptest.ResponseRecorder` object, but there could be a better way?
- Now that this is serving up responses, the tests should probably be improved.

cc @benadida 