### PR TITLE
add X-HTTP-Science header to all forwarded requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func forwardRequest(r *http.Request, addr string) (string, error) {
 	}
 	defer conn.Close()
 	read := bufio.NewReader(conn)
+	r.Header.Add("X-HTTP-Science", "1")
 	r.WriteProxy(conn)
 	res, err := http.ReadResponse(read, r)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -32,10 +32,16 @@ type TestCase struct {
 
 func (tc TestCase) Run(t *testing.T) {
 	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-HTTP-Science") != "1" {
+			t.Fatalf("Did not have X-HTTP-Science header")
+		}
 		fmt.Fprintln(w, tc.Control.Body)
 	}))
 	defer control.Close()
 	experiment := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-HTTP-Science") != "1" {
+			t.Fatalf("Did not have X-HTTP-Science header")
+		}
 		fmt.Fprintln(w, tc.Experiment.Body)
 	}))
 	defer experiment.Close()


### PR DESCRIPTION
what: adds a header to requests it forwards

why: it's useful to identify these requests, specifically so that we don't re-sample them for science.