### PR TITLE
Record error with write proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,9 @@ func forwardRequest(r *http.Request, addr string) (string, error) {
 	}
 	defer conn.Close()
 	read := bufio.NewReader(conn)
-	r.WriteProxy(conn)
+	if err = r.WriteProxy(conn); err != nil {
+		return "", fmt.Errorf("error initializing write proxy to %s: %s", addr, err)
+	}
 	res, err := http.ReadResponse(read, r)
 	if err != nil {
 		return "", fmt.Errorf("error reading response from %s: %s", addr, err)


### PR DESCRIPTION
I don't think this is the reason we stop logging diffs, but I figure we should
fix it either way.