### PR TITLE
Go Vendoring Standardization

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: bradrydzewski/go:1.4
+image: clever/drone-go:1.5
 notify:
   email:
     recipients:
@@ -24,4 +24,5 @@ publish:
     when:
       branch: master
 script:
-  - make all
+- make test
+- make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM google/debian:wheezy
-
+FROM debian:jessie
 COPY build/linux-amd64/http-science /usr/local/bin/http-science
-
 CMD ["http-science"]

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,8 @@
+{
+	"ImportPath": "github.com/Clever/http-science",
+	"GoVersion": "go1.5.1",
+	"Packages": [
+		"github.com/Clever/http-science"
+	],
+	"Deps": []
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,15 @@ build/linux-amd64: $(GOPATH)/bin/gox
 	GOARCH=amd64 GOOS=linux go build -o "$@/$(EXECUTABLE)" $(PKG)
 
 build: $(BUILDS)
+
+
+SHELL := /bin/bash
+PKGS := $(shell go list ./... | grep -v /vendor)
+GODEP := $(GOPATH)/bin/godep
+
+$(GODEP):
+	go get -u github.com/tools/godep
+
+vendor: $(GODEP)
+	$(GODEP) save $(PKGS)
+	find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X # remove any nested vendor directories

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
 SHELL := /bin/bash
 PKG = github.com/Clever/http-science
+PKGS := $(shell go list ./... | grep -v /vendor)
 GOLINT := $(GOPATH)/bin/golint
+.PHONY: build all vendor $(PKGS)
+
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+GODEP := $(GOPATH)/bin/godep
+$(GODEP):
+	go get -u github.com/tools/godep
 
 test: $(PKG)
 
 all: build test
-
-$(GOLINT):
-	go get github.com/golang/lint/golint
 
 $(PKG): $(GOLINT) $(GODEP)
 	go install $@
@@ -36,14 +43,6 @@ build/linux-amd64: $(GOPATH)/bin/gox
 	GOARCH=amd64 GOOS=linux go build -o "$@/$(EXECUTABLE)" $(PKG)
 
 build: $(BUILDS)
-
-
-SHELL := /bin/bash
-PKGS := $(shell go list ./... | grep -v /vendor)
-GODEP := $(GOPATH)/bin/godep
-
-$(GODEP):
-	go get -u github.com/tools/godep
 
 vendor: $(GODEP)
 	$(GODEP) save $(PKGS)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 SHELL := /bin/bash
 PKG = github.com/Clever/http-science
 PKGS := $(shell go list ./... | grep -v /vendor)
-GOLINT := $(GOPATH)/bin/golint
+EXECUTABLE := http-science
 .PHONY: build all vendor $(PKGS)
+
+all: test build
 
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
@@ -12,34 +14,22 @@ GODEP := $(GOPATH)/bin/godep
 $(GODEP):
 	go get -u github.com/tools/godep
 
-test: $(PKG)
+test: $(PKGS)
 
-all: build test
-
-$(PKG): $(GOLINT) $(GODEP)
+$(PKGS): $(GOLINT)
 	go install $@
 	gofmt -w=true $(GOPATH)/src/$@/*.go
 	$(GOLINT) $(GOPATH)/src/$@/*.go
-ifeq ($(COVERAGE),1)
-	go test -cover -coverprofile=$(GOPATH)/src/$@/c.out $@ -test.v
-	go tool cover -html=$(GOPATH)/src/$@/c.out
-else
 	@echo "TESTING $@..."
 	go test -v $@
-endif
 
-EXECUTABLE := http-science
 BUILDS := \
 	build/linux-amd64 \
 	build/darwin-amd64
 
-$(GOPATH)/bin/gox:
-	go get github.com/mitchellh/gox
-build/darwin-amd64: $(GOPATH)/bin/gox
-	sudo PATH=$$PATH:`go env GOROOT`/bin $(GOPATH)/bin/gox -build-toolchain -os darwin -arch amd64
+build/darwin-amd64:
 	GOARCH=amd64 GOOS=darwin go build -o "$@/$(EXECUTABLE)" $(PKG)
-build/linux-amd64: $(GOPATH)/bin/gox
-	sudo PATH=$$PATH:`go env GOROOT`/bin $(GOPATH)/bin/gox -build-toolchain -os linux -arch amd64
+build/linux-amd64:
 	GOARCH=amd64 GOOS=linux go build -o "$@/$(EXECUTABLE)" $(PKG)
 
 build: $(BUILDS)

--- a/README.md
+++ b/README.md
@@ -26,34 +26,6 @@ Assuming you have two versions of an HTTP service deployed, it takes care of for
 Once launched, `http-science` listens for HTTP requests on port 80, and will forward any request it receives to both `CONTROL` and `EXPERIMENT`.
 If there is a difference in responses, it will log a report of the difference.
 
+## Vendoring
 
-## Developing
-
-`make test` runs the tests.
-
-`make build` will build binaries for Linux and Mac OS.
-
-## Changing Dependencies
-
-### New Packages
-
-When adding a new package, you can simply use `make vendor` to update your imports.
-This should bring in the new dependency that was previously undeclared.
-The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
-
-### Existing Packages
-
-First ensure that you have your desired version of the package checked out in your `$GOPATH`.
-
-When to change the version of an existing package, you will need to use the godep tool.
-You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
-So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
-
-```
-# depending on github.com/Clever/foo
-godep update github.com/Clever/foo
-
-# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
-godep update github.com/Clever/foo/a github.com/Clever/foo/b
-```
-
+Please view the [dev-handbook for instructions](https://github.com/Clever/dev-handbook/blob/master/golang/godep.md).

--- a/README.md
+++ b/README.md
@@ -32,3 +32,28 @@ If there is a difference in responses, it will log a report of the difference.
 `make test` runs the tests.
 
 `make build` will build binaries for Linux and Mac OS.
+
+## Changing Dependencies
+
+### New Packages
+
+When adding a new package, you can simply use `make vendor` to update your imports.
+This should bring in the new dependency that was previously undeclared.
+The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
+
+### Existing Packages
+
+First ensure that you have your desired version of the package checked out in your `$GOPATH`.
+
+When to change the version of an existing package, you will need to use the godep tool.
+You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
+So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
+
+```
+# depending on github.com/Clever/foo
+godep update github.com/Clever/foo
+
+# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
+godep update github.com/Clever/foo/a github.com/Clever/foo/b
+```
+

--- a/main_test.go
+++ b/main_test.go
@@ -92,7 +92,7 @@ func TestScience(t *testing.T) {
 GET / HTTP/1.1
 Host: {{.Host}}
 Accept-Encoding: gzip
-User-Agent: Go 1.1 package http
+User-Agent: Go-http-client/1.1
 
 
 ---


### PR DESCRIPTION
This PR was mostly autogenerated.

Changes to expect:
- removal of `*_test.go` files in /vendor
- addition of non go files in /vendor
- addtions to README.md & Makefile

**Before your merge!**:

- Please carefully check the Makefile changes
- Ensure that the build is passing
- Check that drone is using the proper image (Clever/drone-go:1.5)

Feel free to ping @natebrennand or #golang for clarification or help.

If you'd like more of an explanation please join us in #golang.