### PR TITLE
Add check that email was sent

### DIFF
--- a/email/email.go
+++ b/email/email.go
@@ -29,6 +29,12 @@ func SendEmail(payload *config.Payload, duration time.Duration, res science.Resu
 	templateName := "http-science-results"
 
 	mandrillClient := mandrill.ClientWithKey(os.Getenv("MANDRILL_KEY"))
-	_, err := mandrillClient.MessagesSendTemplate(message, templateName, map[string]string{})
-	return err
+
+	resp, err := mandrillClient.MessagesSendTemplate(message, templateName, nil)
+	if err != nil {
+		return err
+	} else if resp[0].Status != "Sent" {
+		return fmt.Errorf("Email not sent, status: %s, reason: %s", resp[0].Status, resp[0].RejectionReason)
+	}
+	return nil
 }


### PR DESCRIPTION
We were previously getting `Status:"rejected", RejectionReason:"invalid-sender"` because I hadn't configured the new mandrill template correctly (didn't specify a from address). I have changed that and this should check for similar errors in future.