### PR TITLE
Json compare

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ publish:
     - $(git rev-parse --short HEAD)
     username: $$docker_username
     when:
-      branch: master
+      branch: json-compare
   report_card: {}
 script:
 - make test

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ publish:
     - $(git rev-parse --short HEAD)
     username: $$docker_username
     when:
-      branch: json-compare
+      branch: master
   report_card: {}
 script:
 - make test

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,9 @@ import (
 // KV is this worker's Kayvee logger
 var KV = logger.New("http-science")
 
+// WeakCompare if set to true by the payload allows arrays to be out of order in the json comparison
+var WeakCompare = false
+
 // Payload is the payload specifiying info for a load test
 type Payload struct {
 	// Required
@@ -17,6 +20,7 @@ type Payload struct {
 	ExperimentURL string `json:"experiment_url"`
 	ControlURL    string `json:"control_url"`
 	DiffLoc       string `json:"diff_loc"`
+	WeakCompare   bool   `json:"weak_equal"`
 	// Only Load
 	LoadURL string `json:"load_url"`
 	// Optional

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func logResults(startTime time.Time, payload *config.Payload) error {
 		science.Res.Mutex.Lock()
 		log.Printf("Results %#v", science.Res.Codes)
 		science.Res.Mutex.Unlock()
-		log.Printf("%d Diffs", science.Res.Diffs)
+		log.Printf("%d Diffs using weak compare: %t", science.Res.Diffs, config.WeakCompare)
 
 		// Assert difflog is a file - we use the fact that it is a ReadWriter in the tests
 		diffLog, ok := science.Res.DiffLog.(*os.File)

--- a/science/common.go
+++ b/science/common.go
@@ -50,6 +50,7 @@ func forwardRequest(r *http.Request, addr string, cleanup []string) (*forwardedR
 	if err != nil {
 		return &forwardedRequest{}, fmt.Errorf("error reading response from %s: %s", addr, err)
 	}
+	defer res.Body.Close()
 
 	cleanupHeaders(res, cleanup)
 

--- a/science/common.go
+++ b/science/common.go
@@ -60,7 +60,7 @@ func forwardRequest(r *http.Request, addr string, cleanup []string) (*forwardedR
 
 	buf, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return &forwardedRequest{}, fmt.Errorf("smt")
+		return &forwardedRequest{}, fmt.Errorf("error reading body from response from %s: %s", addr, err)
 	}
 
 	return &forwardedRequest{

--- a/science/common.go
+++ b/science/common.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -21,38 +22,51 @@ type Results struct {
 	DiffLog io.ReadWriter
 }
 
+type forwardedRequest struct {
+	dump   string
+	body   []byte
+	header http.Header
+	code   int
+}
+
 // Res represents the outcome of science
 var Res Results
 
 // forwardRequest forwards a request to an address and returns the raw HTTP response.
 // It lets you pass a slice of headers that you want removed to make it easier to compare
 // to other responses.
-func forwardRequest(r *http.Request, addr string, cleanup []string) (string, int, error) {
+func forwardRequest(r *http.Request, addr string, cleanup []string) (*forwardedRequest, error) {
+
 	addr = strings.TrimPrefix(addr, "https://")
 	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) // TODO - get tests to work without this
 	if err != nil {
-		return "", 0, fmt.Errorf("error establishing tcp connection to %s: %s", addr, err)
+		return &forwardedRequest{}, fmt.Errorf("error establishing tcp connection to %s: %s", addr, err)
 	}
 	defer conn.Close()
 	if err = r.Write(conn); err != nil {
-		return "", 0, fmt.Errorf("error writing request to %s: %s", addr, err)
+		return &forwardedRequest{}, fmt.Errorf("error writing request to %s: %s", addr, err)
 	}
 	res, err := http.ReadResponse(bufio.NewReader(conn), r)
 	if err != nil {
-		return "", 0, fmt.Errorf("error reading response from %s: %s", addr, err)
+		return &forwardedRequest{}, fmt.Errorf("error reading response from %s: %s", addr, err)
 	}
-	defer res.Body.Close()
-	for _, val := range cleanup {
-		delete(res.Header, val)
-		if val == "Content-Length" {
-			res.ContentLength = 0
-		} else if val == "Transfer-Encoding" {
-			res.TransferEncoding = nil
-		}
-	}
-	resDump, err := httputil.DumpResponse(res, true)
+
+	cleanupHeaders(res, cleanup)
+
+	dump, err := httputil.DumpResponse(res, true)
 	if err != nil {
-		return "", 0, fmt.Errorf("error dumping response from %s: %s", addr, err)
+		return &forwardedRequest{}, fmt.Errorf("error dumping response from %s: %s", addr, err)
 	}
-	return string(resDump), res.StatusCode, nil
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return &forwardedRequest{}, fmt.Errorf("smt")
+	}
+
+	return &forwardedRequest{
+		dump:   string(dump),
+		body:   buf,
+		code:   res.StatusCode,
+		header: res.Header,
+	}, nil
 }

--- a/science/common_test.go
+++ b/science/common_test.go
@@ -28,10 +28,11 @@ func TestForward(t *testing.T) {
 
 	r, err := http.NewRequest("GET", "https://www.example.com", strings.NewReader(testIn))
 	assert.Nil(t, err)
-	resp, code, err := forwardRequest(r, server.URL, []string{})
+	res, err := forwardRequest(r, server.URL, []string{})
 	assert.Nil(t, err)
-	assert.True(t, strings.Contains(resp, testResp))
-	assert.Equal(t, 200, code)
+
+	assert.True(t, strings.Contains(string(res.body), testResp))
+	assert.Equal(t, 200, res.code)
 }
 
 func TestCleanup(t *testing.T) {
@@ -46,9 +47,10 @@ func TestCleanup(t *testing.T) {
 	for _, cleanup := range []string{"Content-Length", "Date"} {
 		r, err := http.NewRequest("GET", "https://www.example.com", nil)
 		assert.Nil(t, err)
-		resp, code, err := forwardRequest(r, server.URL, []string{cleanup})
+		res, err := forwardRequest(r, server.URL, []string{cleanup})
 		assert.Nil(t, err)
-		assert.Equal(t, 200, code)
-		assert.False(t, strings.Contains(resp, cleanup))
+
+		assert.False(t, strings.Contains(string(res.body), cleanup))
+		assert.Equal(t, 200, res.code)
 	}
 }

--- a/science/compare.go
+++ b/science/compare.go
@@ -1,0 +1,133 @@
+package science
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/Clever/http-science/config"
+)
+
+// cleanupHeaders removes headers that can be different for inconsequential reasons
+func cleanupHeaders(res *http.Response, cleanup []string) {
+	for _, val := range cleanup {
+		delete(res.Header, val)
+		if val == "Content-Length" {
+			res.ContentLength = 0
+		} else if val == "Transfer-Encoding" {
+			res.TransferEncoding = nil
+		}
+	}
+}
+
+func codesAreEqual(control, experiment int) bool {
+	return control == experiment
+}
+
+func headersAreEqual(control, experiment http.Header) bool {
+	return reflect.DeepEqual(control, experiment)
+}
+
+func bodiesAreEqual(control, experiment []byte) bool {
+	if isSimplyEqual(control, experiment) {
+		return true
+	}
+	return isJSONEqual(control, experiment)
+}
+
+// isSimplyEqual returns true if the two strings are equal, false otherwise
+func isSimplyEqual(dumpControl, dumpExperiment []byte) bool {
+	return (string(dumpControl) == string(dumpExperiment))
+}
+
+// isJSONEqual compares two responses and returns true if they are equivalent
+// it ignores ordering of keys and elements in maps and arrays in the body
+// it will be fairly inefficient for large objects (n^2 on arrays)
+func isJSONEqual(resControl, resExperiment []byte) bool {
+	var controlJSON, expJSON map[string]interface{}
+	// Return false if they can't be parsed as JSON
+	if err := json.Unmarshal(resControl, &controlJSON); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(resExperiment, &expJSON); err != nil {
+		return false
+	}
+
+	if config.WeakCompare {
+		return msiAreEqual(controlJSON, expJSON)
+	}
+	return reflect.DeepEqual(controlJSON, expJSON)
+}
+
+func msiAreEqual(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	areEqual := true
+	for k, v := range a {
+		switch v := v.(type) {
+		case []interface{}:
+			bv, ok := b[k].([]interface{})
+			if !ok {
+				return false
+			}
+			areEqual = areEqual && sliceAreEqual(v, bv)
+		case map[string]interface{}:
+			bv, ok := b[k].(map[string]interface{})
+			if !ok {
+				return false
+			}
+			areEqual = areEqual && msiAreEqual(v, bv)
+		default:
+			bv, ok := b[k]
+			if !ok {
+				return false
+			}
+			areEqual = areEqual && reflect.DeepEqual(v, bv)
+		}
+		// Early exit if we find a diff
+		if !areEqual {
+			return false
+		}
+	}
+	return true
+}
+
+func sliceAreEqual(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, v := range a {
+		areEqual := false
+		for _, bv := range b {
+
+			switch v := v.(type) {
+			case []interface{}:
+				bv, ok := bv.([]interface{})
+				if !ok {
+					continue
+				}
+				areEqual = sliceAreEqual(v, bv)
+			case map[string]interface{}:
+				bv, ok := bv.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				areEqual = msiAreEqual(v, bv)
+			default:
+				areEqual = reflect.DeepEqual(v, bv)
+			}
+			// Early exit inner loop once we find a match for this item
+			if areEqual {
+				break
+			}
+		}
+		// Early exit outer loop if we didn't find a match for this item
+		if !areEqual {
+			return false
+		}
+	}
+	return true
+}

--- a/science/compare.go
+++ b/science/compare.go
@@ -99,6 +99,7 @@ func sliceAreEqual(a, b []interface{}) bool {
 		return false
 	}
 
+	// This fails when there are duplicates in the first list
 	for _, v := range a {
 		areEqual := false
 		for _, bv := range b {

--- a/science/compare.go
+++ b/science/compare.go
@@ -98,30 +98,35 @@ func sliceAreEqual(a, b []interface{}) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	used := []int{}
 
-	// This fails when there are duplicates in the first list
-	for _, v := range a {
+	for _, v1 := range a {
 		areEqual := false
-		for _, bv := range b {
+		for i, v2 := range b {
+			// Check that we have't already used this element to match
+			if inList(i, used) {
+				continue
+			}
 
-			switch v := v.(type) {
+			switch v1 := v1.(type) {
 			case []interface{}:
-				bv, ok := bv.([]interface{})
+				v2, ok := v2.([]interface{})
 				if !ok {
 					continue
 				}
-				areEqual = sliceAreEqual(v, bv)
+				areEqual = sliceAreEqual(v1, v2)
 			case map[string]interface{}:
-				bv, ok := bv.(map[string]interface{})
+				v2, ok := v2.(map[string]interface{})
 				if !ok {
 					continue
 				}
-				areEqual = msiAreEqual(v, bv)
+				areEqual = msiAreEqual(v1, v2)
 			default:
-				areEqual = reflect.DeepEqual(v, bv)
+				areEqual = reflect.DeepEqual(v1, v2)
 			}
 			// Early exit inner loop once we find a match for this item
 			if areEqual {
+				used = append(used, i)
 				break
 			}
 		}
@@ -131,4 +136,13 @@ func sliceAreEqual(a, b []interface{}) bool {
 		}
 	}
 	return true
+}
+
+func inList(val int, list []int) bool {
+	for _, v := range list {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/science/compare.go
+++ b/science/compare.go
@@ -98,13 +98,13 @@ func sliceAreEqual(a, b []interface{}) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	used := []int{}
+	usedIndexes := []int{}
 
 	for _, v1 := range a {
 		areEqual := false
 		for i, v2 := range b {
 			// Check that we have't already used this element to match
-			if inList(i, used) {
+			if inList(i, usedIndexes) {
 				continue
 			}
 
@@ -126,7 +126,7 @@ func sliceAreEqual(a, b []interface{}) bool {
 			}
 			// Early exit inner loop once we find a match for this item
 			if areEqual {
-				used = append(used, i)
+				usedIndexes = append(usedIndexes, i)
 				break
 			}
 		}
@@ -138,9 +138,9 @@ func sliceAreEqual(a, b []interface{}) bool {
 	return true
 }
 
-func inList(val int, list []int) bool {
-	for _, v := range list {
-		if v == val {
+func inList(v int, list []int) bool {
+	for _, vList := range list {
+		if v == vList {
 			return true
 		}
 	}

--- a/science/compare_test.go
+++ b/science/compare_test.go
@@ -1,0 +1,170 @@
+package science
+
+import (
+	"testing"
+
+	"github.com/Clever/http-science/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleDiffs(t *testing.T) {
+	eq := []byte("test string ';][23")
+	neq := []byte("something else")
+
+	assert.Equal(t, true, isSimplyEqual(eq, eq))
+	assert.Equal(t, false, isSimplyEqual(eq, neq))
+}
+
+func TestJSONDiffs(t *testing.T) {
+
+	// These should be the same with either weak or strong comparisons (no OOO arrays)
+	for _, v := range []bool{true, false} {
+		config.WeakCompare = v
+		// Not equal when one or both are not json
+		not := []byte("not json")
+		jsonSimple2 := []byte(`{"yo": "jt"}`)
+		jsonSimple1 := []byte(`{"yo": "jo"}`)
+		assert.Equal(t, false, isJSONEqual(jsonSimple1, not))
+		assert.Equal(t, false, isJSONEqual(not, not))
+
+		// Correctly handles simple json
+		assert.Equal(t, true, isJSONEqual(jsonSimple1, jsonSimple1))
+		assert.Equal(t, false, isJSONEqual(jsonSimple1, jsonSimple2))
+
+		// Correctly handles out of order keys
+		jsonUnorderedKeys1 := []byte(`{"Hel": "lo", "Wor": "ld"}`)
+		jsonUnorderedKeys2 := []byte(`{"Wor": "ld", "Hel": "lo"}`)
+		assert.Equal(t, true, isJSONEqual(jsonUnorderedKeys1, jsonUnorderedKeys2))
+
+		// Correctly handles nested objects
+		jsonNested1 := []byte(`{"Hel": {"lo": ["Wor", "ld"]}}`)
+		jsonNested2 := []byte(`{"Hel": {"lo": ["Wor", "ld!"]}}`)
+		jsonNestedUnordered1 := []byte(`{"Hel": {"lo": ["Wor", "ld"]}}`)
+		assert.Equal(t, true, isJSONEqual(jsonNested1, jsonNestedUnordered1))
+		assert.Equal(t, false, isJSONEqual(jsonNested1, jsonNested2))
+
+		// Stress test
+		assert.Equal(t, false, isJSONEqual(jsonComplicated, jsonComplicatedDifferent))
+		assert.Equal(t, true, isJSONEqual(jsonComplicated, jsonComplicatedUnorderedKey))
+
+		// OOO arrays and are different with weak vs strong comparison
+		assert.Equal(t, v, isJSONEqual(jsonComplicated, jsonComplicatedUnorderedArray))
+	}
+
+}
+
+var jsonComplicated = []byte(`
+{
+    "id": "0001",
+    "type": "donut",
+    "name": "Cake",
+    "ppu": 0.55,
+    "batters":
+        {
+            "batter":
+                [
+                    { "id": "1001", "type": "Regular" },
+                    { "id": "1002", "type": "Chocolate" },
+                    { "id": "1003", "type": "Blueberry" },
+                    { "id": "1004", "type": "Devil's Food" }
+                ]
+        },
+    "topping":
+        [
+            { "id": "5001", "type": "None" },
+            { "id": "5002", "type": "Glazed" },
+            { "id": "5005", "type": "Sugar" },
+            { "id": "5007", "type": "Powdered Sugar" },
+            { "id": "5006", "type": "Chocolate with Sprinkles" },
+            { "id": "5003", "type": "Chocolate" },
+            { "id": "5004", "type": ["Maple", "Chocolate"] }
+        ]
+}
+`)
+
+var jsonComplicatedUnorderedKey = []byte(`
+{
+    "id": "0001",
+    "name": "Cake",
+    "type": "donut",
+    "ppu": 0.55,
+    "topping":
+        [
+            { "id": "5001", "type": "None" },
+            { "id": "5002", "type": "Glazed" },
+            { "id": "5005", "type": "Sugar" },
+            { "id": "5007", "type": "Powdered Sugar" },
+            { "id": "5006", "type": "Chocolate with Sprinkles" },
+            { "id": "5003", "type": "Chocolate" },
+            { "id": "5004", "type": ["Maple", "Chocolate"] }
+        ],
+    "batters":
+        {
+            "batter":
+                [
+                    { "id": "1001", "type": "Regular" },
+                    { "id": "1002", "type": "Chocolate" },
+                    { "id": "1003", "type": "Blueberry" },
+                    { "id": "1004", "type": "Devil's Food" }
+                ]
+        }
+}
+`)
+
+var jsonComplicatedUnorderedArray = []byte(`
+{
+    "type": "donut",
+    "id": "0001",
+    "ppu": 0.55,
+    "name": "Cake",
+    "batters":
+        {
+            "batter":
+                [
+                    { "id": "1002", "type": "Chocolate" },
+                    { "id": "1001", "type": "Regular" },
+                    { "id": "1003", "type": "Blueberry" },
+                    { "id": "1004", "type": "Devil's Food" }
+                ]
+        },
+    "topping":
+        [
+            { "id": "5002", "type": "Glazed" },
+            { "id": "5001", "type": "None" },
+            { "id": "5007", "type": "Powdered Sugar" },
+            { "id": "5005", "type": "Sugar" },
+            { "id": "5003", "type": "Chocolate" },
+            { "id": "5006", "type": "Chocolate with Sprinkles" },
+            { "id": "5004", "type": ["Maple", "Chocolate"] }
+        ]
+}
+`)
+
+var jsonComplicatedDifferent = []byte(`
+{
+    "id": "0001",
+    "type": "donut",
+    "name": "Cake",
+    "ppu": 0.55,
+    "batters":
+        {
+            "batter":
+                [
+                    { "id": "1001", "type": "Regular" },
+                    { "id": "1002", "type": "Chocolate" },
+                    { "id": "1003", "type": "Blueberry" },
+                    { "id": "1004", "type": "Devil's Food" }
+                ]
+        },
+    "topping":
+        [
+            { "id": "5001", "type": "None" },
+            { "id": "5002", "type": "Glazed" },
+            { "id": "5005", "type": "Sugar" },
+            { "id": "5007", "type": "Powdered Sugar" },
+            { "id": "5006", "type": "Chocolate with Sprinkles" },
+            { "id": "5003", "type": "DIFFERENT TOPPING" },
+            { "id": "5004", "type": ["Maple", "Chocolate"] }
+        ]
+}
+`)

--- a/science/compare_test.go
+++ b/science/compare_test.go
@@ -17,7 +17,6 @@ func TestSimpleDiffs(t *testing.T) {
 
 func TestJSONDiffs(t *testing.T) {
 
-	// These should be the same with either weak or strong comparisons (no OOO arrays)
 	for _, v := range []bool{true, false} {
 		config.WeakCompare = v
 		// Not equal when one or both are not json
@@ -39,9 +38,13 @@ func TestJSONDiffs(t *testing.T) {
 		// Correctly handles nested objects
 		jsonNested1 := []byte(`{"Hel": {"lo": ["Wor", "ld"]}}`)
 		jsonNested2 := []byte(`{"Hel": {"lo": ["Wor", "ld!"]}}`)
-		jsonNestedUnordered1 := []byte(`{"Hel": {"lo": ["Wor", "ld"]}}`)
-		assert.Equal(t, true, isJSONEqual(jsonNested1, jsonNestedUnordered1))
+		assert.Equal(t, true, isJSONEqual(jsonNested1, jsonNested1))
 		assert.Equal(t, false, isJSONEqual(jsonNested1, jsonNested2))
+
+		// We correctly handle duplicates in arrays
+		jsonArrayDup1 := []byte(`{"Hello": ["Wor", "ld!", "ld!"]}}`)
+		jsonArrayDup2 := []byte(`{"Hello": ["Wor", "Wor", "ld!"]}}`)
+		assert.Equal(t, false, isJSONEqual(jsonArrayDup1, jsonArrayDup2))
 
 		// Stress test
 		assert.Equal(t, false, isJSONEqual(jsonComplicated, jsonComplicatedDifferent))
@@ -49,11 +52,6 @@ func TestJSONDiffs(t *testing.T) {
 
 		// OOO arrays and are different with weak vs strong comparison
 		assert.Equal(t, v, isJSONEqual(jsonComplicated, jsonComplicatedUnorderedArray))
-
-		// We correctly handle duplicates in arrays
-		jsonArrayDup1 := []byte(`{"Hello": ["Wor", "ld!", "ld!"]}}`)
-		jsonArrayDup2 := []byte(`{"Hello": ["Wor", "Wor", "ld!"]}}`)
-		assert.Equal(t, false, isJSONEqual(jsonArrayDup1, jsonArrayDup2))
 	}
 
 }

--- a/science/compare_test.go
+++ b/science/compare_test.go
@@ -49,6 +49,11 @@ func TestJSONDiffs(t *testing.T) {
 
 		// OOO arrays and are different with weak vs strong comparison
 		assert.Equal(t, v, isJSONEqual(jsonComplicated, jsonComplicatedUnorderedArray))
+
+		// We correctly handle duplicates in arrays
+		jsonArrayDup1 := []byte(`{"Hello": ["Wor", "ld!", "ld!"]}}`)
+		jsonArrayDup2 := []byte(`{"Hello": ["Wor", "Wor", "ld!"]}}`)
+		assert.Equal(t, false, isJSONEqual(jsonArrayDup1, jsonArrayDup2))
 	}
 
 }

--- a/science/correctness.go
+++ b/science/correctness.go
@@ -19,8 +19,8 @@ type CorrectnessTest struct {
 	ExperimentURL string
 }
 
-var errorForwardingControl = "Error forwarding request Control"
-var errorForwardingExperiment = "Error forwarding request Experiment"
+var errorForwardingControl = []byte("Error forwarding request Control")
+var errorForwardingExperiment = []byte("Error forwarding request Experiment")
 
 func (c CorrectnessTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// save request for potential diff logging
@@ -28,43 +28,30 @@ func (c CorrectnessTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("error dumping request: %s", err)
 	}
-	var resControl, resExperiment string
-	var codeControl, codeExperiment int
-	cleanup := []string{"Date", "Content-Length", "Transfer-Encoding"}
 
-	rControl, rExp, err := duplicateRequest(r)
+	// Body can only be read once so we need to duplicate it
+	rControl, rExperiment, err := duplicateRequest(r)
 	if err != nil {
 		config.KV.ErrorD("duplicating-request-failed", logger.M{"err": err.Error()})
 		return
 	}
 
-	if resControl, codeControl, err = forwardRequest(rControl, c.ControlURL, cleanup); err != nil {
-		config.KV.ErrorD("forwarding-to-control", logger.M{"err": err.Error()})
-		resControl = errorForwardingControl
-		codeControl = -1
-	}
-	if resExperiment, codeExperiment, err = forwardRequest(rExp, c.ExperimentURL, cleanup); err != nil {
-		config.KV.ErrorD("forwarding-to-exp", logger.M{"err": err.Error()})
-		resExperiment = errorForwardingExperiment
-		codeExperiment = -1
-	}
+	// These headers can differ in inconsequential ways so we remove them while forwarding
+	cleanup := []string{"Date", "Content-Length", "Transfer-Encoding"}
+	control, err := forwardRequest(rControl, c.ControlURL, cleanup)
+	handleForwardErr(control, "control", err)
+	experiment, err := forwardRequest(rExperiment, c.ExperimentURL, cleanup)
+	handleForwardErr(experiment, "experiment", err)
 
 	Res.Mutex.Lock()
 	defer Res.Mutex.Unlock()
 	Res.Reqs++
 
-	if resControl != resExperiment || codeControl != codeExperiment {
-		if _, ok := Res.Codes[codeExperiment][codeControl]; !ok {
-			if _, ok := Res.Codes[codeExperiment]; !ok {
-				Res.Codes[codeExperiment] = map[int]int{}
-			}
-			Res.Codes[codeExperiment][codeControl] = 0
-		}
-		Res.Codes[codeExperiment][codeControl]++
-
+	if !codesAreEqual(control.code, experiment.code) || !headersAreEqual(control.header, experiment.header) || !bodiesAreEqual(control.body, experiment.body) {
+		updateCodes(control.code, experiment.code)
 		Res.Diffs++
 		Res.DiffLog.Write(
-			[]byte(fmt.Sprintf("=== diff ===\n%s\n---\n%s\n---\n%s\n============\n", string(reqDump), resControl, resExperiment)),
+			[]byte(fmt.Sprintf("=== diff ===\n%s\n---\n%s\n---\n%s\n============\n", string(reqDump), control.dump, experiment.dump)),
 		)
 	}
 }
@@ -83,4 +70,28 @@ func duplicateRequest(r *http.Request) (*http.Request, *http.Request, error) {
 	r2.Body = ioutil.NopCloser(b2)
 
 	return &r1, &r2, err
+}
+
+func updateCodes(codeControl, codeExperiment int) {
+	if _, ok := Res.Codes[codeExperiment][codeControl]; !ok {
+		if _, ok := Res.Codes[codeExperiment]; !ok {
+			Res.Codes[codeExperiment] = map[int]int{}
+		}
+		Res.Codes[codeExperiment][codeControl] = 0
+	}
+	Res.Codes[codeExperiment][codeControl]++
+}
+
+func handleForwardErr(res *forwardedRequest, which string, err error) {
+	if err != nil {
+		config.KV.ErrorD(fmt.Sprintf("forwarding-to-%s", which), logger.M{"err": err.Error()})
+		res.code = -1
+		if which == "control" {
+			res.body = errorForwardingControl
+			res.dump = string(errorForwardingControl)
+		} else {
+			res.body = errorForwardingExperiment
+			res.dump = string(errorForwardingExperiment)
+		}
+	}
 }

--- a/science/correctness_test.go
+++ b/science/correctness_test.go
@@ -94,7 +94,7 @@ func TestCorrectness(t *testing.T) {
 	assert.Equal(t, 1, Res.Reqs)
 	assert.Equal(t, 1, Res.Diffs)
 	assert.Equal(t, map[int]map[int]int{-1: map[int]int{200: 1}}, Res.Codes)
-	compareDiffLog(t, scienceServer, controlRespWithHeaders, errorForwardingExperiment)
+	compareDiffLog(t, scienceServer, controlRespWithHeaders, string(errorForwardingExperiment))
 
 	// Send both to a server that doesn't exist
 	scienceServer = httptest.NewServer(CorrectnessTest{
@@ -108,7 +108,7 @@ func TestCorrectness(t *testing.T) {
 	assert.Equal(t, 1, Res.Reqs)
 	assert.Equal(t, 1, Res.Diffs)
 	assert.Equal(t, map[int]map[int]int{-1: map[int]int{-1: 1}}, Res.Codes)
-	compareDiffLog(t, scienceServer, errorForwardingControl, errorForwardingExperiment)
+	compareDiffLog(t, scienceServer, string(errorForwardingControl), string(errorForwardingExperiment))
 
 	// Correctly handles GET requests with bodies
 	scienceServer = httptest.NewServer(CorrectnessTest{

--- a/science/load.go
+++ b/science/load.go
@@ -11,7 +11,7 @@ type LoadTest struct {
 }
 
 func (l LoadTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	_, _, err := forwardRequest(r, l.URL, []string{})
+	_, err := forwardRequest(r, l.URL, []string{})
 	if err != nil {
 		log.Printf("Error forwarding request: %s", err)
 		return

--- a/science/load_test.go
+++ b/science/load_test.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func refreshLoadResults() Results {
+	return Results{
+		Reqs:  0,
+		Mutex: &sync.Mutex{},
+	}
+}
 
 func TestLoad(t *testing.T) {
 	loadHandler := http.HandlerFunc(
@@ -19,6 +27,7 @@ func TestLoad(t *testing.T) {
 	defer loadServer.Close()
 
 	// Counts request if successful
+	Res = refreshLoadResults()
 	scienceServer := httptest.NewServer(LoadTest{
 		URL: loadServer.URL,
 	})
@@ -28,6 +37,7 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, 1, Res.Reqs)
 
 	// Doesn't count request if it fails
+	Res = refreshLoadResults()
 	scienceServer = httptest.NewServer(LoadTest{
 		URL: "localhost:not_a_port",
 	})

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -81,5 +81,8 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		return nil, fmt.Errorf("email given but no MANDRILL_KEY")
 	}
 
+	if payload.WeakCompare {
+		config.WeakCompare = true
+	}
 	return payload, nil
 }


### PR DESCRIPTION
This adds the option to do json diffing. We try a simple string match between the bodies and if that fails we try to do a json comparison.

In the json comparison, we ignore differences in the order of keys (correct according to the json spec), and add the option (by default OFF) to ignore ordering in arrays (incorrect according to the json spec). However we need to do this second part as in some places we use go maps.

These is a bit of refactoring to allow us to do this.

Fairly extensive tests of the comparisons have been added.

I'll run some sanity tests in dev to test this too.