### PR TITLE
getfiles: Actually decompress the entire file.

### DIFF
--- a/getfiles/getfiles.go
+++ b/getfiles/getfiles.go
@@ -90,9 +90,6 @@ func downloadFile(file string) (string, error) {
 			return "", err
 		}
 		finalRes = append(finalRes, res[:n]...)
-		if n != chunk {
-			break
-		}
 	}
 	filename := fmt.Sprintf("%s/%s.txt", os.TempDir(), strings.Split(finalPath(file), ".")[0])
 	pathio.Write(filename, finalRes)


### PR DESCRIPTION
`Read()` makes no guarantee that the number of returned bytes is equal to
the number of requested bytes, so this was almost always exiting the
loop early. For example, the file I tested with only listed 60 requests
before this commit even though there were actually 1940 requests in the
file.