### PR TITLE
only lock where we really need to

### DIFF
--- a/science/correctness.go
+++ b/science/correctness.go
@@ -46,11 +46,13 @@ func (c CorrectnessTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	experiment, err := forwardRequest(rExperiment, c.ExperimentURL, cleanup)
 	handleForwardErr(experiment, "experiment", err)
 
+	hasDiff := !codesAreEqual(control.code, experiment.code) || !headersAreEqual(control.header, experiment.header) || !bodiesAreEqual(control.body, experiment.body)
+
 	Res.Mutex.Lock()
 	defer Res.Mutex.Unlock()
 	Res.Reqs++
 
-	if !codesAreEqual(control.code, experiment.code) || !headersAreEqual(control.header, experiment.header) || !bodiesAreEqual(control.body, experiment.body) {
+	if hasDiff {
 		updateCodes(control.code, experiment.code)
 		Res.Diffs++
 		Res.DiffLog.Write(


### PR DESCRIPTION
I'm not 100% sure what is happening, but I think that with weak_equal, comparisons of very large docs takes a very long time (it is an n^2 process). While doing that comparison, nothing else can make progress as we lock during the check. That is unnecessary - there is no concurrent access to anything in the checks.

Todo is maybe to try make weak equal more performant, but this should alleviate it a bit.