### PR TITLE
Close readers after error checking

### DIFF
--- a/getfiles/getfiles.go
+++ b/getfiles/getfiles.go
@@ -68,16 +68,16 @@ func AddFilesToChan(payload *config.Payload, files chan<- string) error {
 // downloadFile downloads, unzips and writes to /tmp/filename.txt
 func downloadFile(file string) (string, error) {
 	reader, err := pathio.Reader(file)
+	if err != nil {
+		return "", err
+	}
 	defer reader.Close()
 
-	if err != nil {
-		return "", err
-	}
 	decompress, err := gzip.NewReader(reader)
-	defer decompress.Close()
 	if err != nil {
 		return "", err
 	}
+	defer decompress.Close()
 
 	finalRes := []byte{}
 	chunk := 10000 // read in 10KB chunks


### PR DESCRIPTION
We were getting nil pointer dereference errors because `defer reader.Close()` was being called before checking that there are no errors.
```
Thu 19:29:56.844 http-science/cff26bae~> panic: runtime error: invalid memory address or nil pointer dereference
Thu 19:29:56.844 http-science/cff26bae~> [signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x5b0a92]
Thu 19:29:56.844 http-science/cff26bae~> goroutine 6 [running]:
Thu 19:29:56.844 http-science/cff26bae~> panic(0x6fcfa0, 0xc420016060)
Thu 19:29:56.844 http-science/cff26bae~> #011/usr/local/go/src/runtime/panic.go:500 +0x1a1
Thu 19:29:56.844 http-science/cff26bae~> compress/gzip.(*Reader).Close(0x0, 0x8adde0, 0xc420016840)
Thu 19:29:56.844 http-science/cff26bae~> #011/usr/local/go/src/compress/gzip/gunzip.go:287 +0x22
Thu 19:29:56.844 http-science/cff26bae~> github.com/Clever/http-science/getfiles.downloadFile(0xc420086640, 0x91, 0x0, 0x0, 0x8adde0, 0xc420016840)
Thu 19:29:56.844 http-science/cff26bae~> #011/var/cache/drone/src/github.com/Clever/http-science/getfiles/getfiles.go:79 +0x5c9
```

This PR fixes it.