### PR TITLE
Concurrent rate limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,14 @@ var KV = logger.New("http-science")
 // WeakCompare if set to true by the payload allows arrays to be out of order in the json comparison
 var WeakCompare = false
 
-// Concurrency is the max number of concurrent requests. Ignored if < 0
-var Concurrency = -1
-
-// ConcurrencyMutex lets us access concurrency safely
-var ConcurrencyMutex = &sync.Mutex{}
+// Concurrency is the max number of concurrent requests and a mutex. Ignored if value < 0
+var Concurrency = struct {
+	Value int
+	Mutex *sync.Mutex
+}{
+	Value: -1,
+	Mutex: &sync.Mutex{},
+}
 
 // Payload is the payload specifiying info for a load test
 type Payload struct {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"sync"
 
 	"gopkg.in/Clever/kayvee-go.v3/logger"
 )
@@ -11,6 +12,12 @@ var KV = logger.New("http-science")
 
 // WeakCompare if set to true by the payload allows arrays to be out of order in the json comparison
 var WeakCompare = false
+
+// Concurrency is the max number of concurrent requests. Ignored if < 0
+var Concurrency = -1
+
+// ConcurrencyMutex lets us access concurrency safely
+var ConcurrencyMutex = &sync.Mutex{}
 
 // Payload is the payload specifiying info for a load test
 type Payload struct {
@@ -24,10 +31,11 @@ type Payload struct {
 	WeakCompare   bool   `json:"weak_equal"`
 	// Only Load
 	LoadURL string `json:"load_url"`
+	Speed   int    `json:"speed"`
 	// Optional
+	Concurrency      int    `json:"concurrency"`
 	FilePrefix       string `json:"file_prefix"`
 	Reqs             int    `json:"reqs"`
-	Speed            int    `json:"speed"`
 	JobNumber        int    `json:"job_number"`
 	TotalJobs        int    `json:"total_jobs"`
 	StartBefore      string `json:"start_before"`

--- a/science/correctness.go
+++ b/science/correctness.go
@@ -24,14 +24,14 @@ var errorForwardingExperiment = []byte("Error forwarding request Experiment")
 
 func (c CorrectnessTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Bail if too many concurrent requests, else update concurrency if we are using it
-	config.ConcurrencyMutex.Lock()
-	if config.Concurrency == 0 {
+	config.Concurrency.Mutex.Lock()
+	if config.Concurrency.Value == 0 {
 		w.WriteHeader(200)
 		return
-	} else if config.Concurrency > 0 {
-		config.Concurrency--
+	} else if config.Concurrency.Value > 0 {
+		config.Concurrency.Value--
 	}
-	config.ConcurrencyMutex.Unlock()
+	config.Concurrency.Mutex.Unlock()
 
 	// save request for potential diff logging
 	reqDump, err := httputil.DumpRequest(r, true)
@@ -57,11 +57,11 @@ func (c CorrectnessTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handleForwardErr(experiment, "experiment", err)
 
 	// Update concurrency if we are using it
-	config.ConcurrencyMutex.Lock()
-	if config.Concurrency != -1 {
-		config.Concurrency++
+	config.Concurrency.Mutex.Lock()
+	if config.Concurrency.Value != -1 {
+		config.Concurrency.Value++
 	}
-	config.ConcurrencyMutex.Unlock()
+	config.Concurrency.Mutex.Unlock()
 
 	hasDiff := !codesAreEqual(control.code, experiment.code) || !headersAreEqual(control.header, experiment.header) || !bodiesAreEqual(control.body, experiment.body)
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -54,7 +54,7 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 	// Set default speed
 	if payload.Concurrency != 0 {
 		payload.Speed = 10000 // set really high speed, we will control with concurrency
-		config.Concurrency = payload.Concurrency
+		config.Concurrency.Value = payload.Concurrency
 	} else if payload.Speed == 0 {
 		payload.Speed = 100
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -17,6 +17,9 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		if payload.LoadURL == "" {
 			return nil, fmt.Errorf("Payload must contain 'load_url' if job_type is load")
 		}
+		if payload.Speed != 0 && payload.Concurrency != 0 {
+			return nil, fmt.Errorf("Payload can't contain both speed an concurrency")
+		}
 	case "correctness":
 		if payload.ExperimentURL == "" || payload.ControlURL == "" {
 			return nil, fmt.Errorf("Payload must contain 'experiment_url' and 'control_url' if job_type is correctness")
@@ -24,6 +27,10 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		if payload.DiffLoc == "" {
 			return nil, fmt.Errorf("Payload must contain 'diff_loc' if job_type is correctness")
 		}
+		if payload.Speed != 0 {
+			return nil, fmt.Errorf("Payload can't contain speed if job_type is correctness. Use concurrency")
+		}
+
 	default:
 		return nil, fmt.Errorf("Payload.job_type must be 'load' or 'correctness', got %s", payload.JobType)
 	}
@@ -44,10 +51,14 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		return nil, fmt.Errorf("file_prefix should not start or end with slash if used with 's3_bucket'")
 	}
 
-	// Set speed and reqs to defaults if not specified
-	if payload.Speed == 0 {
+	// Set default speed
+	if payload.Concurrency != 0 {
+		payload.Speed = 10000 // set really high speed, we will control with concurrency
+		config.Concurrency = payload.Concurrency
+	} else if payload.Speed == 0 {
 		payload.Speed = 100
 	}
+	// Set default reqs
 	if payload.Reqs == 0 {
 		payload.Reqs = 1000
 	}
@@ -81,8 +92,6 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		return nil, fmt.Errorf("email given but no MANDRILL_KEY")
 	}
 
-	if payload.WeakCompare {
-		config.WeakCompare = true
-	}
+	config.WeakCompare = payload.WeakCompare
 	return payload, nil
 }


### PR DESCRIPTION
Add a concurrency option rather than speed for correctness tests.

Speed is hard to use.