### PR TITLE
remove gearcmd pass-sigterm flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ COPY build/linux-amd64/http-science /usr/local/bin/http-science
 CMD ["gearcmd", \
     "--name", "http-science", \
     "--cmd", "/usr/local/bin/http-science", \
-    "--parseargs=false", \
-    "pass-sigterm"]
+    "--parseargs=false" ]


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2746

We are moving to `workflow-manager`. Part of that process involves removing unused gearcmd flags.

If you believe this was removed in error, please let me know!

