### PR TITLE
Update Gearcmd to v0.10.0 -- defaults pass-sigterm to true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get -y update && apt-get install -y curl wget flex bison make build-esse
   curl -L https://github.com/Clever/gor/releases/download/v0.13.6/gor_0.13.6_x64.tar.gz | tar xvz -C /usr/local/bin/ && chmod +x /usr/local/bin/gor && \
   wget http://www.tcpdump.org/release/libpcap-1.7.4.tar.gz && tar xzf libpcap-1.7.4.tar.gz && cd libpcap-1.7.4 && \
     ./configure && make install && cd .. && rm -rf libpcap-1.7.4 && \
-  curl -L https://github.com/Clever/gearcmd/releases/download/0.8.7/gearcmd-v0.8.7-linux-amd64.tar.gz | \
+  curl -L https://github.com/Clever/gearcmd/releases/download/0.10.0/gearcmd-v0.10.0-linux-amd64.tar.gz | \
     tar xz -C /usr/local/bin --strip-components 1
 
 COPY build/linux-amd64/http-science /usr/local/bin/http-science


### PR DESCRIPTION

Context: https://github.com/Clever/gearcmd/pull/67

We make this the default in order to match signal handling behavior in
sfncli (https://github.com/Clever/sfncli). We want to know ahead of time
if any application isn't handling sigterm correctly before moving to workflows.

Note: If this breaks application behavior, please

(0) set `pass-sigterm=false` in Dockerfile and redeploy
(1) add a note here
(2) let @xavi- or someone on eng-infra know

Thanks!