### PR TITLE
Migrating http-science's to sfncli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM debian:jessie
 
 # Can't just apt-get install libpcap because this is the recommended version and ubuntu only had 1.5.3-2
-RUN apt-get -y update && apt-get install -y curl wget flex bison make build-essential && \
-  curl -L https://github.com/Clever/gor/releases/download/v0.13.6/gor_0.13.6_x64.tar.gz | tar xvz -C /usr/local/bin/ && chmod +x /usr/local/bin/gor && \
-  wget http://www.tcpdump.org/release/libpcap-1.7.4.tar.gz && tar xzf libpcap-1.7.4.tar.gz && cd libpcap-1.7.4 && \
-    ./configure && make install && cd .. && rm -rf libpcap-1.7.4 && \
-  curl -L https://github.com/Clever/gearcmd/releases/download/0.10.0/gearcmd-v0.10.0-linux-amd64.tar.gz | \
-    tar xz -C /usr/local/bin --strip-components 1
+RUN apt-get -y update && \
+    apt-get install -y curl wget flex bison make build-essential && \
+    curl -L https://github.com/Clever/gor/releases/download/v0.13.6/gor_0.13.6_x64.tar.gz | tar xvz -C /usr/local/bin/ && \
+    chmod +x /usr/local/bin/gor && \
+    wget http://www.tcpdump.org/release/libpcap-1.7.4.tar.gz && \
+    tar xzf libpcap-1.7.4.tar.gz && \
+    cd libpcap-1.7.4 && \
+    ./configure && \
+    make install && \
+    cd .. && \
+    rm -rf libpcap-1.7.4 && \
+    apt-get install -y ca-certificates
 
+COPY bin/sfncli /usr/bin/sfncli
 COPY build/linux-amd64/http-science /usr/local/bin/http-science
 
-CMD ["gearcmd", \
-    "--name", "http-science", \
-    "--cmd", "/usr/local/bin/http-science", \
-    "--parseargs=false", \
-    "pass-sigterm"]
+CMD ["/usr/bin/sfncli", "--cmd", "/usr/local/bin/http-science", "--activityname", "${_DEPLOY_ENV}--${_APP_NAME}", "--region", "us-west-2", "--cloudwatchregion", "us-west-1", "--workername", "MAGIC_ECS_TASK_ARN"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include sfncli.mk
 include golang.mk
 .DEFAULT_GOAL := test # override default goal set in library makefile
 
@@ -6,6 +7,7 @@ SHELL := /bin/bash
 PKG = github.com/Clever/http-science
 PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := $(shell basename $(PKG))
+SFNCLI_VERSION := latest
 $(eval $(call golang-version-check,1.9))
 
 BUILDS := \
@@ -16,7 +18,7 @@ all: test build
 build/linux-amd64:
 	GOARCH=amd64 GOOS=linux go build -o "$@/$(EXECUTABLE)" $(PKG)
 
-build: clean $(BUILDS)
+build: clean $(BUILDS) bin/sfncli
 
 clean:
 	-rm -rf build

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.2.0
+GOLANG_MK_VERSION := 0.3.5
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -18,7 +18,7 @@ define golang-version-check
 _ := $(if  \
 		$(shell  \
 			expr >/dev/null  \
-				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f2`  \
+				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f2 | sed -E 's/beta[0-9]+//'`  \
 				\>= `echo $(1) | cut -d. -f2`  \
 				\&  \
 				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f1`  \
@@ -36,25 +36,45 @@ $(FGT):
 golang-ensure-curl-installed:
 	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
 
-DEP_VERSION = v0.3.2
+DEP_VERSION = v0.4.1
 DEP_INSTALLED := $(shell [[ -e "bin/dep" ]] && bin/dep version | grep version | grep -v go | cut -d: -f2 | tr -d '[:space:]')
 # Dep is a tool used to manage Golang dependencies. It is the offical vendoring experiment, but
 # not yet the official tool for Golang.
+ifeq ($(DEP_VERSION),$(DEP_INSTALLED))
+bin/dep: # nothing to do, dep is already up-to-date
+else
+CACHED_DEP = /tmp/dep-$(DEP_VERSION)
 bin/dep: golang-ensure-curl-installed
+	@echo "Updating dep..."
 	@mkdir -p bin
-	@[[ "$(DEP_VERSION)" != "$(DEP_INSTALLED)" ]] && \
-		echo "Updating dep..." && \
-		curl -o bin/dep -sL https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(SYSTEM)-amd64 && \
-		chmod +x bin/dep || true
+	@if [ ! -f $(CACHED_DEP) ]; then curl -o $(CACHED_DEP) -sL https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(SYSTEM)-amd64; fi;
+	@cp $(CACHED_DEP) bin/dep
+	@chmod +x bin/dep || true
+endif
 
-golang-dep-vendor-deps: bin/dep
+# figure out "github.com/<org>/<repo>"
+# `go list` will fail if there are no .go files in the directory
+# if this is the case, fall back to assuming github.com/Clever
+REF = $(shell go list || echo github.com/Clever/$(notdir $(shell pwd)))
+golang-verify-no-self-references:
+	@if grep -q -i "$(REF)" Gopkg.lock; then echo "Error: Gopkg.lock includes a self-reference ($(REF)), which is not allowed. See: https://github.com/golang/dep/issues/1690" && exit 1; fi;
+	@if grep -q -i "$(REF)" Gopkg.toml; then echo "Error: Gopkg.toml includes a self-reference ($(REF)), which is not allowed. See: https://github.com/golang/dep/issues/1690" && exit 1; fi;
+
+golang-dep-vendor-deps: bin/dep golang-verify-no-self-references
 
 # golang-godep-vendor is a target for saving dependencies with the dep tool
 # to the vendor/ directory. All nested vendor/ directories are deleted via
 # the prune command.
+# In CI, -vendor-only is used to avoid updating the lock file.
+ifndef CI
 define golang-dep-vendor
-bin/dep ensure
+bin/dep ensure -v
 endef
+else
+define golang-dep-vendor
+bin/dep ensure -v -vendor-only
+endef
+endif
 
 # Golint is a tool for linting Golang code for common errors.
 GOLINT := $(GOPATH)/bin/golint
@@ -145,6 +165,19 @@ $(call golang-fmt,$(1))
 $(call golang-lint-strict,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
+endef
+
+# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# arg1: pkg path
+# arg2: executable name
+define golang-build
+@echo "BUILDING..."
+@if [ -z "$$CI" ]; then \
+	go build -o bin/$(2) $(1); \
+else \
+	echo "-> Building CGO binary"; \
+	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
+fi;
 endef
 
 # golang-update-makefile downloads latest version of golang.mk

--- a/launch/http-science.yml
+++ b/launch/http-science.yml
@@ -8,7 +8,6 @@ env:
 - MANDRILL_KEY
 dependencies:
 - gearman-admin
-- gearmand
 team: eng-secure-sync
 aws:
   s3:
@@ -19,3 +18,6 @@ aws:
     write:
     - replay-testing
   custom: true
+  managed:
+    clever:
+    - Workflows

--- a/sfncli.mk
+++ b/sfncli.mk
@@ -1,0 +1,29 @@
+# This is the default sfncli Makefile.
+# Please do not alter this file directly.
+SFNCLI_MK_VERSION := 0.1.0
+SHELL := /bin/bash
+SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
+SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
+SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest | grep tag_name | cut -d\" -f4)
+
+.PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
+
+ensure-sfncli-version-set:
+	@ if [[ "$(SFNCLI_VERSION)" = "" ]]; then \
+		echo "SFNCLI_VERSION not set in Makefile - Suggest setting 'SFNCLI_VERSION := latest'"; \
+		exit 1; \
+	fi
+
+ensure-curl-installed:
+	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
+
+bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
+	@mkdir -p bin
+	$(eval SFNCLI_VERSION := $(if $(filter latest,$(SFNCLI_VERSION)),$(SFNCLI_LATEST),$(SFNCLI_VERSION)))
+	@echo "Checking for sfncli updates..."
+	@echo "Using sfncli version $(SFNCLI_VERSION)"
+	@[[ "$(SFNCLI_VERSION)" != "$(SFNCLI_INSTALLED)" ]] && echo "Updating sfncli..." && curl -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && chmod +x bin/sfncli || true
+
+sfncli-update-makefile: ensure-curl-installed
+	@curl -o /tmp/sfncli.mk -sL https://raw.githubusercontent.com/Clever/sfncli/master/make/sfncli.mk
+	@if ! grep -q $(SFNCLI_MK_VERSION) /tmp/sfncli.mk; then cp /tmp/sfncli.mk sfncli.mk && echo "sfncli.mk updated"; else echo "sfncli.mk is up-to-date"; fi


### PR DESCRIPTION
## This an automated PR

*Risk rating*: Major :skull:  **Don't merge.**  Just Review.

If this worker relies on T_T or on JOB_ID for more than logging, holler.  If this worker talks directly to gearman, scream.  That's really not good.

Infra will schedule time to roll this migration out in production.

## Details:

We're killing gearman, which means by proxy we're killing gearcmd.  Workers must now use sfncli.  This PR migrates workers to sfncli.

**New constraints**:
- Workers must take JSON as input
- Workers must use `stderr` for logging.  Only results can go to `stdout`.
- Workers must use [Catapult roles](https://clever.atlassian.net/wiki/spaces/ENG/pages/106506447/AWS+Identity+IAM+STS+Roles#AWSIdentity(IAM,STS,Roles)-CatapultIAMroles(awsinlaunch.yml))

Also gearman-admin is going a way.  Hubble is the new hawtness: https://production--hubble.int.clever.com/multiverse:master/workflows

Jira: https://clever.atlassian.net/browse/INFRA-2755
Spec: https://docs.google.com/document/d/1bqMTEfHXXqFMu-kFftS3hLZoqW3FPTUq2FzcU02BO38/edit
