### PR TITLE
ServiceName field to determine other config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Assuming that your target is running at <URL>, start a basic load test with PAYL
 ```
 {
   "job_type": "load", // Required
-  "load_url": "<URL>", // Required
-  "s3_bucket": "bucketname" // Required
+  "service_name": "<SERVICE_NAME>" // Required
+  "load_env": "<ENV>", // Required
 }
 ```
 
@@ -46,9 +46,9 @@ Assuming that your control is running at <ControlURL>, and your experiment at <E
 ```
 {
   "job_type": "correctness", // Required
-  "control_url": "<ControlURL>", // Required
-  "experiment_url": "<ExperimentURL>", // Required
-  "s3_bucket": "bucketname" // Required
+  "service_name": "<SERVICE_NAME>" // Required
+  "control_env": "<ENV>", // Required
+  "experiment_env": "<ENV>", // Required
   "diff_loc": "s3://bucket/prefix/file" // Required, can be s3 or local path
 }
 ```
@@ -58,7 +58,6 @@ Assuming that your control is running at <ControlURL>, and your experiment at <E
 The following params can be included in the payload for both load and correctness testing to give more control over the test:
 ```
 {
-  "file_prefix": "this/service", // Default ""
   "start_before": "2016/05/31:23", // Default 9999/99/99:99
   "speed": 300, // Default 100
   "reqs": 1000, // Default 1000

--- a/config/config.go
+++ b/config/config.go
@@ -28,20 +28,22 @@ var Concurrency = struct {
 // Payload is the payload specifiying info for a load test
 type Payload struct {
 	// Required
-	JobType  string `json:"job_type"`
-	S3Bucket string `json:"s3_bucket"`
+	JobType     string `json:"job_type"`
+	ServiceName string `json:"service_name"`
 	// Only Correctness
-	ExperimentURL  string   `json:"experiment_url"`
-	ControlURL     string   `json:"control_url"`
+	ExperimentEnv  string   `json:"experiment_env"`
+	ControlEnv     string   `json:"control_env"`
+	ExperimentURL  string   // initialized in validate.go
+	ControlURL     string   // initialized in validate.go
 	DiffLoc        string   `json:"diff_loc"`
 	WeakCompare    bool     `json:"weak_equal"`
 	IgnoredHeaders []string `json:"ignored_headers"`
 	// Only Load
-	LoadURL string `json:"load_url"`
+	LoadEnv string `json:"load_env"`
+	LoadURL string // initialized in validate.go
 	Speed   int    `json:"speed"`
 	// Optional
 	Concurrency      int    `json:"concurrency"`
-	FilePrefix       string `json:"file_prefix"`
 	Reqs             int    `json:"reqs"`
 	JobNumber        int    `json:"job_number"`
 	TotalJobs        int    `json:"total_jobs"`

--- a/getfiles/getfiles.go
+++ b/getfiles/getfiles.go
@@ -18,17 +18,9 @@ import (
 
 // AddFilesToChan adds files from the specified location to a chan
 func AddFilesToChan(payload *config.Payload, files chan<- string) error {
-	base := "%s"
-	if payload.S3Bucket != "" {
-		base = fmt.Sprintf("s3://%s/%%s", payload.S3Bucket)
-	} else {
-		return fmt.Errorf("Currently only supports s3 files")
-	}
-
-	baseWithPrefix := fmt.Sprintf(base, payload.FilePrefix)
-	if payload.FilePrefix != "" {
-		baseWithPrefix += "/"
-	}
+	base := "s3://firehose-prod/%s"
+	filePrefix := fmt.Sprintf("replay-testing/%s/", payload.ServiceName)
+	baseWithPrefix := fmt.Sprintf(base, filePrefix)
 
 	// Starting with the baseWithPrefix, build a stack of directories to explore and
 	// files to download.


### PR DESCRIPTION
Change payload to take in `ServiceName` and envs flags. This way we only need to specify the service name once in the payload and we can infer all of the other information from it

old sample payload:
```
{
  "concurrency": 10,
  "control_url": "https://clever-dev--events-api.int.clever.com:443",
  "diff_loc": "s3://replay-testing/john_events-api_2019-03-28.txt",
  "email": "john.huang@clever.com",
  "experiment_url": "https://john--events-api.int.clever.com:443",
  "file_prefix": "replay-testing/events-api",
  "job_type": "correctness",
  "reqs": 50000,
  "s3_bucket": "firehose-prod"
}
```

new sample payload:
```
{
  "concurrency": 10,
  "service_name": "events-api",
  "control_env": "clever-dev",
  "experiment_env": "john",
  "diff_loc": "s3://replay-testing/john_events-api_2019-03-28.txt",
  "email": "john.huang@clever.com",
  "job_type": "correctness",
  "reqs": 50000,
}
```

Added docs here:
https://clever.atlassian.net/wiki/spaces/ENG/pages/76415097/http-science