### PR TITLE
Add optional pod id field to payload

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type Payload struct {
 	DisallowURLRegex string `json:"disallow_url_regex"`
 	AllowURLRegex    string `json:"allow_url_regex"`
 	Port             string `json:"port"`
+	PodID            string `json:"pod_id"`
 }
 
 // LogAndExitIfErr KV logs and exits with code 1 if there is an error

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -23,7 +23,12 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		if payload.Speed != 0 && payload.Concurrency != 0 {
 			return nil, fmt.Errorf("Payload can't contain both speed an concurrency")
 		}
-		payload.LoadURL = fmt.Sprintf("https://%s--%s.int.clever.com:443", payload.LoadEnv, payload.ServiceName)
+		podID := ""
+		if payload.PodID != "" {
+			podID = fmt.Sprintf("--%s", payload.PodID)
+		}
+
+		payload.LoadURL = fmt.Sprintf("https://%s--%s%s.int.clever.com:443", payload.LoadEnv, payload.ServiceName, podID)
 	case "correctness":
 		port := "443"
 		if payload.Port != "" {
@@ -38,8 +43,12 @@ func Payload(payload *config.Payload) (*config.Payload, error) {
 		if payload.Speed != 0 {
 			return nil, fmt.Errorf("Payload can't contain speed if job_type is correctness. Use concurrency")
 		}
-		payload.ControlURL = fmt.Sprintf("https://%s--%s.int.clever.com:%s", payload.ControlEnv, payload.ServiceName, port)
-		payload.ExperimentURL = fmt.Sprintf("https://%s--%s.int.clever.com:%s", payload.ExperimentEnv, payload.ServiceName, port)
+		podID := ""
+		if payload.PodID != "" {
+			podID = fmt.Sprintf("--%s", payload.PodID)
+		}
+		payload.ControlURL = fmt.Sprintf("https://%s--%s%s.int.clever.com:%s", payload.ControlEnv, payload.ServiceName, podID, port)
+		payload.ExperimentURL = fmt.Sprintf("https://%s--%s%s.int.clever.com:%s", payload.ExperimentEnv, payload.ServiceName, podID, port)
 	default:
 		return nil, fmt.Errorf("Payload.job_type must be 'load' or 'correctness', got %s", payload.JobType)
 	}


### PR DESCRIPTION
With some services being moved to pods, it would be useful to specify an optional `podID` param. Without the pod ID, I am seeing a forwarding error (e.g `error establishing tcp connection to ilel-exp--sso-cil-event-logs-service.int.clever.com:443: dial tcp: lookup ilel-exp--sso-cil-event-logs-service.int.clever.com on 10.0.0.2:53: no such host`)