### PR TITLE
change pod group to uw2

### DIFF
--- a/launch/http-science.yml
+++ b/launch/http-science.yml
@@ -4,29 +4,29 @@ resources:
   cpu: 0.25
   max_mem: 0.5
 env:
-- MANDRILL_KEY
+  - MANDRILL_KEY
 dependencies:
-- gearman-admin
+  - gearman-admin
 team: eng-api
 aws:
   s3:
     read:
-    - firehose-prod
-    - firehose-staging
-    - replay-testing
+      - firehose-prod
+      - firehose-staging
+      - replay-testing
     write:
-    - replay-testing
+      - replay-testing
   custom: true
   managed:
     clever:
-    - Workflows
+      - Workflows
 pod_config:
-  group: us-west-1
+  group: us-west-2
 deploy_config:
   canaryInProd: false
   autoDeployEnvs:
-  - clever-dev
-  - production
+    - clever-dev
+    - production
 mesh_config:
   dev:
     state: mesh_only


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/INFRANG-5936

# Overview:
This PR migrates the app to us-west-2

# Testing:

Dev:
1. Deploy in us-west-2 clever-dev or dev-infra environment (merging not mandatory)
2. Restart upstream services
3. Team owners to test if dev service is functional in us-west-2
4. Kill the older deployment in us-west-1 after confirming successful deploy and traffic flow/activity

Prod:
1. Get approval from app owners
2. Deploy in us-west-2 after merging
3. Restart upstream services
4. Traffic to pods can be verified in Grafana
5. Kill the older prod deployment in us-west-1 after a minimum of 3 days only after confirming all traffic is coming thru to the new deployment
