### PR TITLE
remove mesh_config

### DIFF
--- a/launch/http-science.yml
+++ b/launch/http-science.yml
@@ -4,31 +4,26 @@ resources:
   cpu: 0.25
   max_mem: 0.5
 env:
-  - MANDRILL_KEY
+- MANDRILL_KEY
 dependencies:
-  - gearman-admin
+- gearman-admin
 team: eng-api
 aws:
   s3:
     read:
-      - firehose-prod
-      - firehose-staging
-      - replay-testing
+    - firehose-prod
+    - firehose-staging
+    - replay-testing
     write:
-      - replay-testing
+    - replay-testing
   custom: true
   managed:
     clever:
-      - Workflows
+    - Workflows
 pod_config:
   group: us-west-2
 deploy_config:
   canaryInProd: false
   autoDeployEnvs:
-    - clever-dev
-    - production
-mesh_config:
-  dev:
-    state: mesh_only
-  prod:
-    state: mesh_only
+  - clever-dev
+  - production


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6012

# Overview
Delete the mesh config as we are exiting mesh and this mesh_config is not used anymore.

# Testing
Currently catapult is using a feature flag in place of this mesh config and the feature flag is set to "alb_only" for this app. Which means this is already running in production

# Rollout
Merge PR and deploy via dapple
