### PR TITLE
Update sfncli.mk

### DIFF
--- a/sfncli.mk
+++ b/sfncli.mk
@@ -6,7 +6,11 @@ SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
 # AUTH_HEADER is used to help avoid github ratelimiting
 AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
-SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest  | grep tag_name | cut -d\" -f4)
+SFNCLI_LATEST = $(shell \
+	curl --retry 5 -f -s --header "$(AUTH_HEADER)" \
+		https://api.github.com/repos/Clever/sfncli/releases/latest | \
+	grep tag_name | \
+	cut -d\" -f4)
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 

--- a/sfncli.mk
+++ b/sfncli.mk
@@ -6,8 +6,7 @@ SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
 # AUTH_HEADER is used to help avoid github ratelimiting
 AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
-SFNCLI_LATEST = $(shell \
-	curl -f -s https://api.github.com/repos/Clever/sfncli/releases | jq -r 'map(select(.prerelease)) | .[0].tag_name')
+SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest  | grep tag_name | cut -d\" -f4)
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRANG-6510

**Overview:**
This change removes the reference to `pre-release` from snfcli.mk and instead relies only on the latest released version. 


**Testing:**
`make build` run locally and then deployed into private environment. After ensuring there were no logged errors and ensuring that it was able to update snfcli to the latest version (0.7.5 as of now).


**Roll Out:**
Deploy the worker via dapple and ensure the correct deployment.
